### PR TITLE
Fix segments2boxes empty input

### DIFF
--- a/utils/general.py
+++ b/utils/general.py
@@ -304,6 +304,8 @@ def segments2boxes(segments):
     for s in segments:
         x, y = s.T  # segment xy
         boxes.append([x.min(), y.min(), x.max(), y.max()])  # cls, xyxy
+    if not boxes:
+        return np.zeros((0, 4))
     return xyxy2xywh(np.array(boxes))  # cls, xywh
 
 


### PR DESCRIPTION
## Summary
- handle empty input in `segments2boxes` to avoid index errors

## Testing
- `python -m py_compile utils/*.py`

------
https://chatgpt.com/codex/tasks/task_e_6875e353d0d48322863dc87b73f27b94